### PR TITLE
Add fallback for justify-content(space-between)

### DIFF
--- a/flex.scss
+++ b/flex.scss
@@ -173,7 +173,11 @@
 	@else if $value == "flex-end" {
 		-webkit-box-pack: end;
 		-ms-flex-pack: end;
-	} 
+	}
+	@else if $value == "space-between" {
+		-webkit-box-pack: justify;
+		-ms-flex-pack: justify;
+	}
 	@else { 
 		-webkit-box-pack: $value;
 		-ms-flex-pack: $value;


### PR DESCRIPTION
This includes the "justify" property for Legacy and Microsoft flexbox syntax.
