### PR TITLE
Check if the argument passed to flex() is a list and return the right value. Fixes #10.

### DIFF
--- a/flex.scss
+++ b/flex.scss
@@ -253,7 +253,18 @@
 // http://w3.org/tr/css3-flexbox/#flex-property
 
 @mixin flex($fg: 1, $fs: null, $fb: null) {
-	-webkit-box-flex: $fg;
+
+	// Box-Flex only supports a flex-grow value so let's grab the
+	// first item in the list and just return that.
+	@if type-of($fg) == 'list' {
+		$fg: nth($fg, 1);
+		-webkit-box-flex: $fg;
+	}
+	// If the user wrote their include properly, just return the right value.
+	@else {
+		-webkit-box-flex: $fg;
+	}
+
 	-webkit-flex: $fg $fs $fb;
 	-moz-box-flex: $fg;
 	-moz-flex: $fg $fs $fb;


### PR DESCRIPTION
This fixes #10.
