### PR TITLE
Update @mixin flex() to accomodate box-flex

### DIFF
--- a/flex.scss
+++ b/flex.scss
@@ -253,20 +253,19 @@
 // http://w3.org/tr/css3-flexbox/#flex-property
 
 @mixin flex($fg: 1, $fs: null, $fb: null) {
+    
+	// Set a variable to be used by box-flex properties
+	$fg-boxflex: $fg;
 
 	// Box-Flex only supports a flex-grow value so let's grab the
 	// first item in the list and just return that.
 	@if type-of($fg) == 'list' {
-		$fg: nth($fg, 1);
-		-webkit-box-flex: $fg;
-	}
-	// If the user wrote their include properly, just return the right value.
-	@else {
-		-webkit-box-flex: $fg;
+		$fg-boxflex: nth($fg, 1);
 	}
 
+	-webkit-box-flex: $fg-boxflex;
 	-webkit-flex: $fg $fs $fb;
-	-moz-box-flex: $fg;
+	-moz-box-flex: $fg-boxflex;
 	-moz-flex: $fg $fs $fb;
 	-ms-flex: $fg $fs $fb;
 	flex: $fg $fs $fb;


### PR DESCRIPTION
So the previous pull request #11 was actually broken.

The output of `@mixin flex()` when given a list wasn't filling out all the properties correctly.

This PR should fix that, and ensure that all box-flex properties are filled out appropriately too!

Now both, for example, `@include flex(10, 5, 100px)` and `@include flex(10 5 100px)` work!
