### PR TITLE
Make flex shorthand use standard defaults

### DIFF
--- a/_flex.scss
+++ b/_flex.scss
@@ -251,7 +251,7 @@
 //
 // http://w3.org/tr/css3-flexbox/#flex-property
 
-@mixin flex($fg: 1, $fs: null, $fb: null) {
+@mixin flex($fg: 0, $fs: 1, $fb: auto) {
     
 	// Set a variable to be used by box-flex properties
 	$fg-boxflex: $fg;


### PR DESCRIPTION
As pointed out in the internet's go-to guide to flexbox:
https://css-tricks.com/snippets/css/a-guide-to-flexbox/

The default values for the `flex()` shorthand are `0 1 auto`. This change reflects that.